### PR TITLE
Feature: Dealer Peek Logic with Auto-Reset on Immediate Blackjack Outcome

### DIFF
--- a/Blackjack-iOS.xcodeproj/xcuserdata/jonniakesson.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Blackjack-iOS.xcodeproj/xcuserdata/jonniakesson.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,22 +3,4 @@
    uuid = "05C6AA24-5681-45A4-9DC6-A8930C2AF870"
    type = "1"
    version = "2.0">
-   <Breakpoints>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
-            uuid = "0A0EF4CD-8CE2-463F-B095-7A1CFC5FD264"
-            shouldBeEnabled = "Yes"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "Blackjack-iOS/Views/Extensions+GameView.swift"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "99"
-            endingLineNumber = "99"
-            landmarkName = "unknown"
-            landmarkType = "0">
-         </BreakpointContent>
-      </BreakpointProxy>
-   </Breakpoints>
 </Bucket>

--- a/Blackjack-iOS/DevMenu/DevScenario.swift
+++ b/Blackjack-iOS/DevMenu/DevScenario.swift
@@ -3,7 +3,9 @@ enum DevScenario: String, CaseIterable, Identifiable {
     case forceSplitScenario
     case forceSplitScenarioLeftHandBlackjack
     case forcePlayerBlackjack
-    case forceAceScenarios
+    case forceAceScenariosDealerBJ
+    case forceAceScenariosBothBJ
+    case forceAceScenariosNeitherBJ
     
     var id: String { rawValue }
 }
@@ -19,8 +21,12 @@ extension DevScenario {
             return "Split & Left BJ"
         case .forcePlayerBlackjack:
             return "Force Player Blackjack"
-        case .forceAceScenarios:
-            return "Force Ace Scenarios"
+        case .forceAceScenariosDealerBJ:
+            return "Force Ace: Dealer Blackjack"
+        case .forceAceScenariosBothBJ:
+            return "Force Ace: Both Blackjack"
+        case .forceAceScenariosNeitherBJ:
+            return "Force Ace: Neither Blackjack"
         }
     }
 }

--- a/Blackjack-iOS/Mangers/MockDeckManager.swift
+++ b/Blackjack-iOS/Mangers/MockDeckManager.swift
@@ -1,10 +1,8 @@
 import Foundation
 
-
 struct MockDeckManager {
     static func forceSplitScenario() -> [Card] {
         return [
-            // 4 cards to deal: P1, D1, P2, D2
             Card(suit: .spades, rank: .eight),   // Player 1: 8♠
             Card(suit: .hearts, rank: .king),    // Dealer 1: K♥
             Card(suit: .diamonds, rank: .eight), // Player 2: 8♦
@@ -15,13 +13,13 @@ struct MockDeckManager {
     static func forcePlayerBlackjack() -> [Card] {
         return [
             Card(suit: .spades, rank: .ace),      // Player 1: A♠
-            Card(suit: .hearts, rank: .six),      // Dealer 1: 6♥ (any card, not Ace/10)
+            Card(suit: .hearts, rank: .six),      // Dealer 1: 6♥
             Card(suit: .diamonds, rank: .king),   // Player 2: K♦
-            Card(suit: .clubs, rank: .nine),      // Dealer 2: 9♣ (any)
+            Card(suit: .clubs, rank: .nine),      // Dealer 2: 9♣
         ]
     }
     
-    static func forceSplitScenarioleftHandBlackjack() -> [Card] {
+    static func forceSplitScenarioLeftHandBlackjack() -> [Card] {
         return [
             Card(suit: .spades, rank: .ace),      // Player 1: A♠
             Card(suit: .hearts, rank: .king),     // Dealer 1: K♥
@@ -39,6 +37,36 @@ struct MockDeckManager {
             Card(suit: .clubs, rank: .eight),     // Player 2: 8♣
             Card(suit: .diamonds, rank: .five),   // Dealer 2: 5♦
             Card(suit: .spades, rank: .five),     // Player draws 5♠ (forces ace as 1)
+        ]
+    }
+    
+    static func forceAceScenariosDealerBJ() -> [Card] {
+        // Player: 9♣, 7♦   Dealer: A♠ (up), K♥ (down) → Dealer blackjack
+        return [
+            Card(suit: .clubs, rank: .nine),    // Player 1
+            Card(suit: .spades, rank: .ace),    // Dealer 1 (face up)
+            Card(suit: .diamonds, rank: .seven),// Player 2
+            Card(suit: .hearts, rank: .king),   // Dealer 2 (face down)
+        ]
+    }
+
+    static func forceAceScenariosBothBJ() -> [Card] {
+        // Player: A♣, K♠   Dealer: A♠ (up), K♥ (down) → Both blackjack (push)
+        return [
+            Card(suit: .clubs, rank: .ace),     // Player 1
+            Card(suit: .spades, rank: .ace),    // Dealer 1 (face up)
+            Card(suit: .spades, rank: .king),   // Player 2
+            Card(suit: .hearts, rank: .king),   // Dealer 2 (face down)
+        ]
+    }
+
+    static func forceAceScenariosNeitherBJ() -> [Card] {
+        // Player: 9♣, 7♦   Dealer: A♠ (up), 8♥ (down) → No one has blackjack
+        return [
+            Card(suit: .clubs, rank: .nine),    // Player 1
+            Card(suit: .spades, rank: .ace),    // Dealer 1 (face up)
+            Card(suit: .diamonds, rank: .seven),// Player 2
+            Card(suit: .hearts, rank: .eight),  // Dealer 2 (face down)
         ]
     }
 }

--- a/Blackjack-iOS/Views/Extensions+GameView.swift
+++ b/Blackjack-iOS/Views/Extensions+GameView.swift
@@ -1,15 +1,9 @@
-//
-//  Extensions+GameView.swift
-//  Blackjack-iOS
-//
-//  Created by Jonni Akesson on 2025-07-16.
-//
-
 import SwiftUI
 
-// MARK: - Dealer Draw Logic
+// MARK: - Dealer Logic
 
 extension GameView {
+    /// Dealer draws cards until reaching 17 or higher, then checks for outcome.
     func dealerDrawLoop() {
         func drawNextCard(after delay: TimeInterval) {
             DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
@@ -23,11 +17,59 @@ extension GameView {
         }
         drawNextCard(after: animationSpeed.delay)
     }
+    
+    /// Determines if the dealer should peek at their face-down card for blackjack.
+    func dealerShouldPeek() -> Bool {
+        // Dealer peeks if upcard is Ace or 10/J/Q/K
+        guard dealerCards.count >= 1 else { return false }
+        let upcard = dealerCards[0]
+        return upcard.rank == .ace || upcard.pipValue == 10
+    }
+    
+    /// Returns true if dealer has blackjack with the first two cards.
+    func isDealerBlackjack() -> Bool {
+        guard dealerCards.count >= 2 else { return false }
+        let ranks = [dealerCards[0].rank, dealerCards[1].rank]
+        let tenRanks: [Rank] = [.ten, .jack, .queen, .king]
+        return (ranks.contains(.ace) && ranks.contains(where: { tenRanks.contains($0) }))
+    }
+}
+
+// MARK: - Blackjack Logic
+
+extension GameView {
+    /// Returns true if the given cards represent a blackjack (Ace + 10-value card).
+    func isPlayerBlackjack(_ cards: [Card]) -> Bool {
+        guard cards.count == 2 else { return false }
+        let ranks = [cards[0].rank, cards[1].rank]
+        let tenRanks: [Rank] = [.ten, .jack, .queen, .king]
+        return (ranks.contains(.ace) && ranks.contains(where: { tenRanks.contains($0) }))
+    }
+    
+    /// Calculates the best blackjack hand value, handling Aces as 1 or 11.
+    func calculateHandScore(_ cards: [Card]) -> Int {
+        var total = 0
+        var aceCount = 0
+        for card in cards {
+            if card.rank == .ace {
+                aceCount += 1
+                total += 11
+            } else {
+                total += card.pipValue
+            }
+        }
+        while total > 21 && aceCount > 0 {
+            total -= 10
+            aceCount -= 1
+        }
+        return total
+    }
 }
 
 // MARK: - Outcome & Result Logic
 
 extension GameView {
+    /// Determines and sets the game outcome, then schedules game reset.
     func checkForOutcome() {
         let outcomeDelay = animationSpeed.delay + 0.5
         DispatchQueue.main.asyncAfter(deadline: .now() + outcomeDelay) {
@@ -54,31 +96,20 @@ extension GameView {
     }
 }
 
-// MARK: - Blackjack Logic
-
-extension GameView {
-    func isPlayerBlackjack(_ cards: [Card]) -> Bool {
-        guard cards.count == 2 else { return false }
-        let ranks = [cards[0].rank, cards[1].rank]
-        let tenRanks: [Rank] = [.ten, .jack, .queen, .king]
-        return (ranks.contains(.ace) && ranks.contains(where: { tenRanks.contains($0) }))
-    }
-}
-
 // MARK: - Split Logic
 
 extension GameView {
+    /// Handles player split action, dealing one card to each split hand.
     func handleSplitTapped() {
         guard playerCards.count == 2 else { return }
-        // 1. Move second card to split hand
+        // Move second card to split hand
         let splitCard = playerCards.removeLast()
         playerSplitCards = [splitCard]
         didSplit = true
         canSplit = false
-
-        // 2. Immediately deal one card to each hand (with animation)
+        
         let delayUnit = animationSpeed.delay
-
+        
         // Deal to left/main hand
         DispatchQueue.main.asyncAfter(deadline: .now() + delayUnit) {
             if let card = deck.dealOne() {
@@ -89,16 +120,34 @@ extension GameView {
                 if let card = deck.dealOne() {
                     playerSplitCards.append(card)
                 }
-                // 3. Set to start with first hand (activeHand = 0)
+                // Set active hand to first (left)
                 activeHand = 0
             }
         }
     }
 }
 
+// MARK: - Player Actions
+
+extension GameView {
+    /// Handles the stand action for the current player hand.
+    func playerStands() {
+        guard gamePhase == .playerTurn else { return }
+        if didSplit && activeHand == 0 {
+            activeHand = 1 // Play right (split) hand next
+            return
+        }
+        withAnimation {
+            gamePhase = .dealerTurn
+        }
+        dealerDrawLoop()
+    }
+}
+
 // MARK: - Game State/Reset
 
 extension GameView {
+    /// Resets all game state to start a new round.
     func resetGame() {
         dealerCards.removeAll()
         playerCards.removeAll()
@@ -112,31 +161,5 @@ extension GameView {
         activeHand = 0
         gamePhase = .idle
         deck.reset()
-    }
-}
-
-// MARK: - Player Action Logic
-
-extension GameView {
-    func playerStands() {
-        guard gamePhase == .playerTurn else { return }
-        if didSplit && activeHand == 0 {
-            activeHand = 1 // Now play the split hand
-            return
-        }
-        withAnimation {
-            gamePhase = .dealerTurn
-        }
-        func drawNextCard(after delay: TimeInterval) {
-            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-                if dealerScore < 17, let card = deck.dealOne() {
-                    dealerCards.append(card)
-                    drawNextCard(after: animationSpeed.delay)
-                } else {
-                    checkForOutcome()
-                }
-            }
-        }
-        drawNextCard(after: animationSpeed.delay)
     }
 }

--- a/Blackjack-iOS/Views/FanCardsView.swift
+++ b/Blackjack-iOS/Views/FanCardsView.swift
@@ -1,44 +1,59 @@
 import SwiftUI
 
-
 struct FanCardsView: View {
     let cards: [Card]
     let isDealerCard: Bool
     let isGameOver: Bool
     let dealerScore: Int
     let playerScore: Int
+    let dealerRevealed: Bool
     let isPlayerTurn = true
     let highlighted: Bool
-    
+
     private let scoreHeaderHeight: CGFloat = 30
     private let cardHeight: CGFloat = 200
     private let cardAspect: CGFloat = 500.0 / 726.0
     private var cardWidth: CGFloat { cardHeight * cardAspect }
     private var overlapAmount: CGFloat { cardWidth * 0.4 }
-    
+
+    /// Score text for header (Dealer shows only upcard value if not revealed; both show "-" if empty)
+    private var scoreDisplay: String {
+        if cards.isEmpty {
+            // No cards dealt yet
+            return "-"
+        }
+        if isDealerCard {
+            // Dealer: show real total only if revealed, otherwise just upcard pipValue
+            if !dealerRevealed {
+                return "\(cards.first!.pipValue)"
+            }
+            return "\(dealerScore)"
+        } else {
+            // Player hand: always show full score (after at least 1 card)
+            return "\(playerScore)"
+        }
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             scoreHeaderView
             GeometryReader { geo in
                 let centerX = geo.size.width / 2
                 let centerY = geo.size.height / 2
-                
                 ZStack {
-                    // 🔆 Only shows the glow if highlighted is true
                     if highlighted {
                         Spotlight(color: .yellow)
                             .position(x: centerX, y: centerY)
-                           // .zIndex(-1)
                     }
                     ForEach(cards.indices, id: \.self) { index in
                         CardView(card: cards[index], isFaceUp: isCardFaceUp(at: index))
                             .frame(height: cardHeight)
                             .position(
                                 x: isGameOver
-                                ? centerX
-                                : cardXPosition(at: index,
-                                                centerX: centerX,
-                                                overlapAmount: overlapAmount),
+                                    ? centerX
+                                    : cardXPosition(at: index,
+                                                    centerX: centerX,
+                                                    overlapAmount: overlapAmount),
                                 y: centerY
                             )
                             .zIndex(Double(index))
@@ -46,25 +61,24 @@ struct FanCardsView: View {
                     }
                 }
                 .animation(.default, value: cards.count)
-                // .border(.blue, width: 2) // Debug: show GeometryReader area
             }
             .frame(height: cardHeight)
         }
         .frame(maxWidth: .infinity, alignment: .center)
         .frame(height: scoreHeaderHeight * 2 + cardHeight)
-        //.border(.yellow, width: 3) // outer container debug
     }
-    
+
+    /// Score header view ("Dealer" or "Player" and score)
     private var scoreHeaderView: some View {
         VStack(spacing: 0) {
             Text(isDealerCard ? "Dealer" : "Player")
                 .frame(height: scoreHeaderHeight)
-            Text("Score: \(isDealerCard ? dealerScore : playerScore)")
+            Text("Score: \(scoreDisplay)")
                 .bold()
                 .frame(height: scoreHeaderHeight)
         }
     }
-    
+
     /// Calculates the horizontal x-position for each card based on its index
     private func cardXPosition(
         at index: Int,
@@ -75,54 +89,39 @@ struct FanCardsView: View {
         let overlapTighteningFactor: CGFloat = 0.05
         let maxOverlapFactor: CGFloat = 0.8
         let halfOverlapMultiplier: CGFloat = 0.5
-        
-        // Determine base spacing between card centers:
-        // - 1 card: centered (no spacing)
-        // - 2 cards: standard overlap spacing
-        // - 3+ cards: tighten spacing for each additional card
+
         let interCardSpacing: CGFloat = {
             switch totalCount {
-            case 1:
-                return 0
-            case 2:
-                return overlapAmount
+            case 1: return 0
+            case 2: return overlapAmount
             case 3...:
                 return overlapAmount * (1 - CGFloat(totalCount - 2) * overlapTighteningFactor)
-            default:
-                return overlapAmount * maxOverlapFactor
+            default: return overlapAmount * maxOverlapFactor
             }
         }()
-        
-        // Dealer’s initial flat deal (first two cards side-by-side):
-        // Anchor at half-fan points, then remove overlap so they sit side-by-side.
+
+        // Dealer’s initial deal (first two cards side-by-side)
         if isDealerCard && index < 2 {
             let halfGap = overlapAmount * halfOverlapMultiplier
             let xPos = centerX + (index == 0 ? -halfGap : halfGap)
             return index == 0 ? xPos - overlapAmount : xPos + overlapAmount
         }
-        
-        // Standard fan layout for all other cases:
+
+        // Standard fan layout
         switch totalCount {
         case 1:
-            // Single card: shift left by half overlap so center aligns
             return centerX - overlapAmount * halfOverlapMultiplier
-            
         case 2:
-            // Two-card fan (e.g., player’s first two cards)
             return centerX + interCardSpacing * (index == 0 ? -halfOverlapMultiplier : halfOverlapMultiplier)
-            
-        default: // totalCount >= 3
-            // Center the fan by calculating the total width and offsetting
+        default:
             let totalWidth = interCardSpacing * CGFloat(totalCount - 1)
             let startX = centerX - totalWidth / 2
             return startX + CGFloat(index) * interCardSpacing
         }
     }
-    
-    /// Determines if a card should be face-up; dealer’s second card remains face-down
+
+    /// Determines if a card should be face-up; dealer’s second card remains face-down until revealed
     private func isCardFaceUp(at index: Int) -> Bool {
-        !(isDealerCard && index == 1)
+        !(isDealerCard && index == 1 && !dealerRevealed)
     }
 }
-
-


### PR DESCRIPTION
Summary

This PR implements the classic Blackjack dealer “peek” mechanic and ensures that the game auto-resets after an immediate dealer blackjack.

Details
	•	Dealer now performs a visual “peek” for 2 seconds when the upcard is an Ace or 10-value card.
	•	If the dealer has blackjack, the correct outcome is shown (“Push” if both player and dealer have blackjack, otherwise “Dealer Wins”).
	•	After a dealer blackjack, the game outcome modal is shown and the game auto-resets after a short delay (for consistent user flow).
	•	Other gameplay/UI logic remains unchanged.

Test Coverage
	•	Tested all dealer peek scenarios (dealer BJ only, both BJ, neither BJ).
	•	Dealer outcome resets automatically as intended after outcome modal.